### PR TITLE
Target lines and ignore branches (Overground)

### DIFF
--- a/howfuckedarethetubes.sh
+++ b/howfuckedarethetubes.sh
@@ -9,10 +9,11 @@ val[6]="quite"
 val[7]="overly"
 val[8]="stupidly"
 val[9]="dangerously"
-val[10]="SO"
-val[11]="MUCH"
-val[12]="WOW VERY"
+val[10]="proper"
+val[11]="SO"
+val[12]="MUCH"
+val[13]="WOW VERY"
 res=`curl --silent cloud.tfl.gov.uk/TrackerNet/LineStatus`
 #ct=`echo $res | grep -o "Delays\|Suspended" | wc -l`
-ct=`echo "$res" | grep '<Status' | grep 'Delays\|Suspended' | wc -l`
+ct=`echo "$res" | grep '<LineStatus\ ' | grep -ic 'MINOR\|MAJOR\|SUSPENDED\|DELAY'`
 echo "the tubes are" ${val[$ct]} "fucked"


### PR DESCRIPTION
Count the tube "Lines" that are down and ignore the Overground branches.
Added a 14th level of fuckedness for TfLRail being included now.
Removed 'wc -l' and using grep to count.